### PR TITLE
fixup! Remove enableNumericTypeConversion method

### DIFF
--- a/lib/dbPool.js
+++ b/lib/dbPool.js
@@ -195,21 +195,6 @@ class DBPool {
   }
 
   /**
-   * @description
-   * Configuration option to return numeric types as a Number instead of a String.
-   * When set to true numeric types for `DBPool.runSql` and `DBPool.prepareExecute` 
-   * will be returned as a Number instead of a String.
-   * @param {boolean} flag - option to return numeric types as a Number instead of a String
-   * @returns {boolean} - resolves to true/false indicating the state of the flag
-   */
-  enableNumericTypeConversion(flag) {
-    if(typeof flag !== 'undefined') {
-      this.enableNumericTypeConversion = flag && true;
-    }
-    return this.enableNumericTypeConversion;
-  }
-
-  /**
    * Shorthand to exec a statement , just provide the sql to run.
    * @param {string} sql - the sql statment to execute.
    * @return {array} - if the SQL returns a result set it is returned as an array of objects.


### PR DESCRIPTION
As mentioned in https://github.com/IBM/nodejs-idb-pconnector/pull/97#discussion_r546900688 , this method should be removed.
I thought I did this in the last PR but must have missed it during merge conflict. The` enableNumericTypeConversion` property of the pool can be accessed and adjusted without this method.